### PR TITLE
Portfolio defaults: add VT10 sizing + costs and chosen exit (ATR trail 1.25× cap 6)

### DIFF
--- a/finalize_portfolio_defaults.py
+++ b/finalize_portfolio_defaults.py
@@ -1,0 +1,17 @@
+﻿import json
+from pathlib import Path
+
+# load the chosen exit rule we produced earlier
+exit_rule = json.loads(Path("exit_out/exit_rule.json").read_text())
+
+cfg = {
+  "name": "Default portfolio",
+  "version": "v1",
+  "costs": { "fees_bps": 5, "slip_bps": 5 },
+  "sizing": { "scheme": "equal_weight", "vt_target": 0.10, "max_leverage": 3.0 },
+  "exit_rule": exit_rule
+}
+
+out = Path("out"); out.mkdir(exist_ok=True)
+(out / "portfolio_defaults.json").write_text(json.dumps(cfg, indent=2))
+print("Wrote out/portfolio_defaults.json")

--- a/out/portfolio_defaults.json
+++ b/out/portfolio_defaults.json
@@ -1,0 +1,34 @@
+{
+  "name": "Default portfolio",
+  "version": "v1",
+  "costs": {
+    "fees_bps": 5,
+    "slip_bps": 5
+  },
+  "sizing": {
+    "scheme": "equal_weight",
+    "vt_target": 0.1,
+    "max_leverage": 3.0
+  },
+  "exit_rule": {
+    "name": "ATR Trail 1.25x OR 6 bars",
+    "family": "atr_trail",
+    "multiplier": 1.25,
+    "cap_bars": 6,
+    "inputs": [
+      "close",
+      "atr"
+    ],
+    "atr": {
+      "window": 14,
+      "method": "rolling_mean_true_range"
+    },
+    "timeframe": {
+      "type": "D",
+      "minutes": null
+    },
+    "source": "exit_harness",
+    "artifact": "exits_hybrid_atr1p25_cap6.csv",
+    "version": "v1"
+  }
+}


### PR DESCRIPTION
Adds a repo-default portfolio config:

- Sizing: equal-weight, vol-target 10% (VT10), max_leverage=3.0
- Costs: fees_bps=5, slip_bps=5
- Exit rule: ATR Trail 1.25× with 6-bar safety cap (ATR14, rolling_mean_true_range)
- Artifact: out/portfolio_defaults.json

Generated by finalize_portfolio_defaults.py to keep it reproducible.
